### PR TITLE
Feat: Add nodejs and npm to DNF dependencies for extension builds

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -26,7 +26,9 @@
       "mscore-fonts-all",
       "zsh",
       "gettext",
-      "sassc"
+      "sassc",
+      "nodejs",
+      "npm"
     ],
     "dnf_swap_ffmpeg": {
       "from": "ffmpeg-free",


### PR DESCRIPTION
I've added `nodejs` and `npm` to the `dnf_packages` list in the `phase2_basic_configuration` section of `packages.json`.

This change is necessary to support the build process of GNOME Shell extensions that rely on `npx` (e.g., for `tsc` - TypeScript compiler), such as 'Quick Settings Tweaks'. The availability of `npx` (included with npm) should resolve build failures related to finding and executing such Node.js-based tools.